### PR TITLE
[FEAT] 계정 탈퇴 구현, 내 문제 정보 및 코드 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     // S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/mildo/dev/api/member/controller/MemberController.java
+++ b/src/main/java/com/mildo/dev/api/member/controller/MemberController.java
@@ -6,10 +6,7 @@ import com.mildo.dev.api.code.domain.dto.CodeLevelDTO;
 import com.mildo.dev.api.code.domain.dto.CodeSolvedListDTO;
 import com.mildo.dev.api.code.domain.dto.SolvedListResponse;
 import com.mildo.dev.api.code.domain.dto.SolvedProblemResponse;
-import com.mildo.dev.api.member.domain.dto.MemberInfoDTO;
-import com.mildo.dev.api.member.domain.dto.ProblemMemberDto;
-import com.mildo.dev.api.member.domain.dto.TokenDto;
-import com.mildo.dev.api.member.domain.dto.TokenRedis;
+import com.mildo.dev.api.member.domain.dto.*;
 import com.mildo.dev.api.member.service.MemberService;
 import com.mildo.dev.api.utils.cookie.CookieUtil;
 import com.mildo.dev.global.exception.exceptionClass.ServerUnstableException;
@@ -30,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -132,6 +130,13 @@ public class MemberController {
     @GetMapping(value="/problem/member", produces="application/json; charset=UTF-8")
     public ResponseEntity<?> problem(@RequestBody MemberInfoDTO vo) {
         ProblemMemberDto res = userService.problemMember(vo);
+        return ResponseEntity.ok(res);
+    }
+
+    @ResponseBody
+    @GetMapping(value="/{studyId}/solved/{memberId}", produces="application/json; charset=UTF-8")
+    public ResponseEntity<?> solvedMember(@PathVariable String memberId, @PathVariable String studyId) {
+        Optional<SolvedMemberListDto> res = userService.solvedMember(memberId, studyId);
         return ResponseEntity.ok(res);
     }
 

--- a/src/main/java/com/mildo/dev/api/member/controller/MemberController.java
+++ b/src/main/java/com/mildo/dev/api/member/controller/MemberController.java
@@ -1,18 +1,23 @@
 package com.mildo.dev.api.member.controller;
 
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
 import com.mildo.dev.api.code.domain.dto.CodeLevelDTO;
 import com.mildo.dev.api.code.domain.dto.CodeSolvedListDTO;
 import com.mildo.dev.api.code.domain.dto.SolvedListResponse;
 import com.mildo.dev.api.code.domain.dto.SolvedProblemResponse;
 import com.mildo.dev.api.member.domain.dto.MemberInfoDTO;
+import com.mildo.dev.api.member.domain.dto.ProblemMemberDto;
 import com.mildo.dev.api.member.domain.dto.TokenDto;
 import com.mildo.dev.api.member.domain.dto.TokenRedis;
 import com.mildo.dev.api.member.service.MemberService;
 import com.mildo.dev.api.utils.cookie.CookieUtil;
+import com.mildo.dev.global.exception.exceptionClass.ServerUnstableException;
 import com.mildo.dev.global.exception.exceptionClass.TokenException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,12 +69,8 @@ public class MemberController {
     @ResponseBody
     @GetMapping(value="/{memberId}/level", produces="application/json; charset=UTF-8")
     public ResponseEntity<?> levelCount(@PathVariable String memberId) {
-        try{
-            SolvedProblemResponse LevelCount = userService.memberLevel(memberId);
-            return ResponseEntity.status(HttpStatus.OK).body(LevelCount);
-        } catch (IllegalArgumentException e){
-            throw  new RuntimeException(e.getMessage());
-        }
+        SolvedProblemResponse LevelCount = userService.memberLevel(memberId);
+        return ResponseEntity.status(HttpStatus.OK).body(LevelCount);
     }
 
     @ResponseBody
@@ -79,12 +80,8 @@ public class MemberController {
                                            @RequestParam(defaultValue = "10") int size,
                                            @RequestParam(required = false) String title)
     {
-        try{
-            SolvedListResponse solvedProblemList = userService.solvedProblemList(memberId, page, size, title);
-            return ResponseEntity.status(HttpStatus.OK).body(solvedProblemList);
-        } catch (IllegalArgumentException e){
-            throw  new RuntimeException(e.getMessage());
-        }
+        SolvedListResponse solvedProblemList = userService.solvedProblemList(memberId, page, size, title);
+        return ResponseEntity.status(HttpStatus.OK).body(solvedProblemList);
     }
 
     @PostMapping("/logout")
@@ -106,20 +103,36 @@ public class MemberController {
 
     @ResponseBody
     @PatchMapping(value = "/member/info", produces="application/json; charset=UTF-8")
-    public ResponseEntity<?> updateUser(@RequestBody MemberInfoDTO vo) {
+    public ResponseEntity<?> updateUser(@Valid @RequestBody MemberInfoDTO vo) {
         MemberInfoDTO res = userService.updateUser(vo);
         return ResponseEntity.status(HttpStatus.OK).body(res);
     }
 
     @ResponseBody
-    @PutMapping(value="/{memberId}/upload", produces="application/json; charset=UTF-8")
+    @PatchMapping(value="/{memberId}/upload", produces="application/json; charset=UTF-8")
     public ResponseEntity<?> uploadFile(@RequestParam("file") MultipartFile file, @PathVariable String memberId) {
         try {
             MemberInfoDTO dto = userService.uploadImg(file, memberId);
             return ResponseEntity.ok(dto);
         } catch (IOException e) {
             throw  new RuntimeException("File not found");
+        }catch (AmazonServiceException e) {
+            throw new ServerUnstableException("S3 업로드 실패");
         }
+    }
+
+    @ResponseBody
+    @DeleteMapping(value="/member/info", produces="application/json; charset=UTF-8")
+    public ResponseEntity<?> deleteMember(@RequestBody MemberInfoDTO vo) {
+        userService.deleteMember(vo);
+        return ResponseEntity.ok("삭제 성공");
+    }
+
+    @ResponseBody
+    @GetMapping(value="/problem/member", produces="application/json; charset=UTF-8")
+    public ResponseEntity<?> problem(@RequestBody MemberInfoDTO vo) {
+        ProblemMemberDto res = userService.problemMember(vo);
+        return ResponseEntity.ok(res);
     }
 
     @GetMapping("/test")

--- a/src/main/java/com/mildo/dev/api/member/domain/dto/MemberInfoDTO.java
+++ b/src/main/java/com/mildo/dev/api/member/domain/dto/MemberInfoDTO.java
@@ -1,5 +1,8 @@
 package com.mildo.dev.api.member.domain.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @ToString
@@ -9,7 +12,12 @@ import lombok.*;
 public class MemberInfoDTO {
 
     private String memberId;
+
+    @Size(min = 1, max = 8, message = "이름은 1~8글자여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]+$", message = "이름에는 특수문자를 포함할 수 없습니다.")
+    @NotBlank(message = "이름은 필수 항목입니다.")
     private String name;
+
     private String email;
     private String studyId;
     private String imgUrl;

--- a/src/main/java/com/mildo/dev/api/member/domain/dto/ProblemMemberDto.java
+++ b/src/main/java/com/mildo/dev/api/member/domain/dto/ProblemMemberDto.java
@@ -1,0 +1,20 @@
+package com.mildo.dev.api.member.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProblemMemberDto {
+
+    private String name;
+    private String memberId;
+    private String imgUrl;
+    private Long solvedCount;
+
+
+}

--- a/src/main/java/com/mildo/dev/api/member/domain/dto/SolvedMemberListDto.java
+++ b/src/main/java/com/mildo/dev/api/member/domain/dto/SolvedMemberListDto.java
@@ -1,0 +1,24 @@
+package com.mildo.dev.api.member.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SolvedMemberListDto {
+
+    private String studyId;
+    private String memberId;
+    private String name;
+    private int solvedProblem;
+    private String imgUrl;
+    private int rank;
+
+    public void setRank(int rank) {
+        this.rank = rank;
+    }
+}

--- a/src/main/java/com/mildo/dev/api/member/domain/entity/MemberEntity.java
+++ b/src/main/java/com/mildo/dev/api/member/domain/entity/MemberEntity.java
@@ -4,15 +4,7 @@ import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.mildo.dev.api.code.domain.entity.CodeEntity;
 import com.mildo.dev.api.code.domain.entity.CommentEntity;
 import com.mildo.dev.api.study.domain.entity.StudyEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -65,13 +57,13 @@ public class MemberEntity {
     @JoinColumn(name = "study_id")
     private StudyEntity studyEntity;
 
-    @OneToMany(mappedBy = "memberEntity")
+    @OneToMany(mappedBy = "memberEntity", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private final List<CodeEntity> codeList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "memberEntity")
+    @OneToMany(mappedBy = "memberEntity", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private final List<CommentEntity> commentEntityList = new ArrayList<>();
 
-    @OneToOne(mappedBy = "memberEntity")
+    @OneToOne(mappedBy = "memberEntity", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private TokenEntity tokenEntity;
 
 //    @OneToOne(mappedBy = "memberEntity")

--- a/src/main/java/com/mildo/dev/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/mildo/dev/api/member/repository/MemberRepository.java
@@ -1,12 +1,14 @@
 package com.mildo.dev.api.member.repository;
 
 import com.mildo.dev.api.member.domain.dto.ProblemMemberDto;
+import com.mildo.dev.api.member.domain.dto.SolvedMemberListDto;
 import com.mildo.dev.api.member.domain.entity.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -24,4 +26,9 @@ public interface MemberRepository extends JpaRepository<MemberEntity, String> {
             "WHERE m.memberId = :memberId " +
             "GROUP BY m.name, m.memberId, m.imgUrl")
     ProblemMemberDto countProblemByMemberId(@Param("memberId") String memberId);
+
+    @Query("SELECT new com.mildo.dev.api.member.domain.dto.SolvedMemberListDto(m.studyEntity.studyId, m.memberId, m.name, m.solvedProblem, m.imgUrl,0) " +
+    "FROM MemberEntity m WHERE m.studyEntity.studyId = :studyId ")
+    List<SolvedMemberListDto> solvedMemberRanking(@Param("studyId") String studyId);
+
 }

--- a/src/main/java/com/mildo/dev/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/mildo/dev/api/member/repository/MemberRepository.java
@@ -1,7 +1,10 @@
 package com.mildo.dev.api.member.repository;
 
+import com.mildo.dev.api.member.domain.dto.ProblemMemberDto;
 import com.mildo.dev.api.member.domain.entity.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,4 +15,13 @@ public interface MemberRepository extends JpaRepository<MemberEntity, String> {
     MemberEntity findByGoogleId(String googleId);
 
     Optional<MemberEntity> findByMemberId(String memberId);
+
+    @Query("SELECT COUNT(m) FROM MemberEntity m WHERE m.studyEntity.studyId = :studyId")
+    long countMembersByStudyId(@Param("studyId") String studyId);
+
+    @Query("SELECT new com.mildo.dev.api.member.domain.dto.ProblemMemberDto(m.name, m.memberId, m.imgUrl, COUNT(c.codeNo)) " +
+            "FROM MemberEntity m LEFT JOIN CodeEntity c ON m.memberId = c.memberEntity.memberId " +
+            "WHERE m.memberId = :memberId " +
+            "GROUP BY m.name, m.memberId, m.imgUrl")
+    ProblemMemberDto countProblemByMemberId(@Param("memberId") String memberId);
 }

--- a/src/main/java/com/mildo/dev/api/member/service/MemberService.java
+++ b/src/main/java/com/mildo/dev/api/member/service/MemberService.java
@@ -8,10 +8,7 @@ import com.mildo.dev.api.code.domain.dto.CodeSolvedListDTO;
 import com.mildo.dev.api.code.domain.dto.SolvedListResponse;
 import com.mildo.dev.api.code.domain.dto.SolvedProblemResponse;
 import com.mildo.dev.api.code.repository.CodeRepository;
-import com.mildo.dev.api.member.domain.dto.MemberInfoDTO;
-import com.mildo.dev.api.member.domain.dto.ProblemMemberDto;
-import com.mildo.dev.api.member.domain.dto.TokenDto;
-import com.mildo.dev.api.member.domain.dto.TokenRedis;
+import com.mildo.dev.api.member.domain.dto.*;
 import com.mildo.dev.api.member.domain.entity.MemberEntity;
 import com.mildo.dev.api.member.domain.entity.TokenEntity;
 import com.mildo.dev.api.member.repository.MemberRepository;
@@ -218,6 +215,27 @@ public class MemberService {
     public ProblemMemberDto problemMember(MemberInfoDTO vo){
         MemberEntity member = vaildMemberId(vo.getMemberId());
         return memberRepository.countProblemByMemberId(vo.getMemberId());
+    }
+
+    public Optional<SolvedMemberListDto> solvedMember(String memberId, String studyId){
+        MemberEntity member = vaildMemberId(memberId);
+
+        List<SolvedMemberListDto> members = memberRepository.solvedMemberRanking(studyId);
+        // sort 메서드를 이용해서 Integer.compare 정수 비교 메서드 사용해서 정렬
+        // a 객체가 0번째 인덱스에 오고 b 객체가 a보다 크면 앞으로 오고 작으면 뒤로 가고 값이 같으면 순서를 바꾸지 않는 방식
+        members.sort((a, b) -> Integer.compare(b.getSolvedProblem(), a.getSolvedProblem()));
+
+        int rank = 1;
+        for (int i = 0; i < members.size(); i++) {
+            if (i > 0 && members.get(i).getSolvedProblem() < members.get(i - 1).getSolvedProblem()) {
+                rank = i + 1;
+            }
+            members.get(i).setRank(rank);
+        }
+
+        return members.stream()
+                .filter(m -> m.getMemberId().equals(memberId))
+                .findFirst();
     }
 
 }

--- a/src/main/java/com/mildo/dev/global/exception/GlobalException.java
+++ b/src/main/java/com/mildo/dev/global/exception/GlobalException.java
@@ -1,8 +1,12 @@
 package com.mildo.dev.global.exception;
 
+import com.mildo.dev.global.exception.exceptionClass.ServerUnstableException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,12 +18,30 @@ import java.util.Map;
 public class GlobalException {
 
     @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<Map<String, String>> handleIllegalArgumentException(RuntimeException ex) {
+    public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException ex) {
         log.info("RuntimeException 예외 발생");
         log.info("RuntimeException = {}",  ex.getMessage());
         Map<String, String> errorResponse = new HashMap<>();
         errorResponse.put("error", ex.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        BindingResult bindingResult = ex.getBindingResult();
+        Map<String, String> errors = new HashMap<>();
+
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            errors.put(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+        return new ResponseEntity<>(errors, HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @ExceptionHandler(ServerUnstableException.class)
+    public ResponseEntity<Map<String, String>> handleServerUnstableExceptionException(ServerUnstableException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(errorResponse);
     }
 
 }

--- a/src/main/java/com/mildo/dev/global/exception/exceptionClass/ServerUnstableException.java
+++ b/src/main/java/com/mildo/dev/global/exception/exceptionClass/ServerUnstableException.java
@@ -1,0 +1,8 @@
+package com.mildo.dev.global.exception.exceptionClass;
+
+public class ServerUnstableException extends RuntimeException{
+
+    public ServerUnstableException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
1. 계정 탈퇴 구현 
  - 리더이면 리더 변경하라고 알림
  - 만약 스터디에 자기 혼자이면 계정 탈퇴 가능 관련 DB모두 삭제
  - 지금 스터디 삭제는 주석 처리 했습니다. 나중에 스터디 삭제 구현되면 그거 사용할 예정입니다.
2. 프로필 업로드 예외처리 추가 S3 객체가 없을 수 있어 없을 시 S3 업로드 실패 라고 알림 
3. 이름 변경할 때 8글자 이내 특수 문자 사용 불가능 기능 추가
  - @Valid 사용하여 예외처리 까지 구현