### PR TITLE
[FIX] RequestBody에서 CustomUser로 수정

### DIFF
--- a/src/main/java/com/mildo/dev/api/member/controller/MemberController.java
+++ b/src/main/java/com/mildo/dev/api/member/controller/MemberController.java
@@ -150,17 +150,28 @@ public class MemberController {
     }
 
     @ResponseBody
-    @DeleteMapping(value="/member/info", produces="application/json; charset=UTF-8")
-    public ResponseEntity<?> deleteMember(@AuthenticationPrincipal CustomUser customUser)
+    @DeleteMapping(value="/{memberId}/info", produces="application/json; charset=UTF-8")
+    public ResponseEntity<?> deleteMember(@PathVariable String memberId,
+                                          @AuthenticationPrincipal CustomUser customUser)
     {
+        if (!memberId.equals(customUser.getMemberId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body("memberId와 로그인한 사용자의 ID가 다릅니다.");
+        }
+
         userService.deleteMember(customUser.getMemberId());
         return ResponseEntity.ok("삭제 성공");
     }
 
     @ResponseBody
-    @GetMapping(value="/problem/member", produces="application/json; charset=UTF-8")
-    public ResponseEntity<?> problem(@AuthenticationPrincipal CustomUser customUser)
+    @GetMapping(value="/problem/{memberId}", produces="application/json; charset=UTF-8")
+    public ResponseEntity<?> problem(@PathVariable String memberId,
+                                     @AuthenticationPrincipal CustomUser customUser)
     {
+        if (!memberId.equals(customUser.getMemberId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body("memberId와 로그인한 사용자의 ID가 다릅니다.");
+        }
         ProblemMemberDto res = userService.problemMember(customUser.getMemberId());
         return ResponseEntity.ok(res);
     }

--- a/src/main/java/com/mildo/dev/api/member/domain/dto/MemberInfoDTO.java
+++ b/src/main/java/com/mildo/dev/api/member/domain/dto/MemberInfoDTO.java
@@ -12,12 +12,7 @@ import lombok.*;
 public class MemberInfoDTO {
 
     private String memberId;
-
-    @Size(min = 1, max = 8, message = "이름은 1~8글자여야 합니다.")
-    @Pattern(regexp = "^[a-zA-Z0-9가-힣]+$", message = "이름에는 특수문자를 포함할 수 없습니다.")
-    @NotBlank(message = "이름은 필수 항목입니다.")
     private String name;
-
     private String email;
     private String studyId;
     private String imgUrl;

--- a/src/main/java/com/mildo/dev/api/member/domain/dto/MemberReNameDto.java
+++ b/src/main/java/com/mildo/dev/api/member/domain/dto/MemberReNameDto.java
@@ -1,0 +1,15 @@
+package com.mildo.dev.api.member.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class MemberReNameDto {
+
+    @Size(min = 1, max = 8, message = "이름은 1~8글자여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]+$", message = "이름에는 특수문자를 포함할 수 없습니다.")
+    @NotBlank(message = "이름은 필수 항목입니다.")
+    private String name;
+}

--- a/src/main/java/com/mildo/dev/api/member/service/MemberService.java
+++ b/src/main/java/com/mildo/dev/api/member/service/MemberService.java
@@ -155,10 +155,10 @@ public class MemberService {
         )).orElseThrow(() -> new RuntimeException("해당 ID의 회원이 존재하지 않습니다."));
     }
 
-    public MemberInfoDTO updateUser(MemberInfoDTO vo) {
-        MemberEntity member = vaildMemberId(vo.getMemberId());
+    public MemberInfoDTO updateUser(MemberReNameDto nameDto, String memberId) {
+        MemberEntity member = vaildMemberId(memberId);
 
-        member.setName(vo.getName());
+        member.setName(nameDto.getName());
         memberRepository.save(member);
         return new MemberInfoDTO( member.getMemberId(),
                 member.getName(),
@@ -192,8 +192,8 @@ public class MemberService {
                 member.getImgUrl());
     }
 
-    public void deleteMember(MemberInfoDTO vo){
-        MemberEntity member = vaildMemberId(vo.getMemberId());
+    public void deleteMember(String memberId){
+        MemberEntity member = vaildMemberId(memberId);
 
         long count = memberRepository.countMembersByStudyId(member.getStudyEntity().getStudyId());
 
@@ -202,7 +202,7 @@ public class MemberService {
         }
 
         if(!basic.equals(member.getImgUrl())){
-            amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, vo.getMemberId()));
+            amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, memberId));
         }
 
         memberRepository.delete(member);
@@ -212,9 +212,9 @@ public class MemberService {
 //        }
     }
 
-    public ProblemMemberDto problemMember(MemberInfoDTO vo){
-        MemberEntity member = vaildMemberId(vo.getMemberId());
-        return memberRepository.countProblemByMemberId(vo.getMemberId());
+    public ProblemMemberDto problemMember(String memberId){
+        MemberEntity member = vaildMemberId(memberId);
+        return memberRepository.countProblemByMemberId(memberId);
     }
 
     public Optional<SolvedMemberListDto> solvedMember(String memberId, String studyId){

--- a/src/main/java/com/mildo/dev/global/oauth/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/mildo/dev/global/oauth/jwt/filter/JwtFilter.java
@@ -52,7 +52,6 @@ public class JwtFilter extends OncePerRequestFilter {
                 pathMatcher.match("/dev-login", requestURI) ||
                 pathMatcher.match("/tokens", requestURI) ||
                 pathMatcher.match("/tokens/refresh", requestURI) ||
-                pathMatcher.match("/logout", requestURI) ||
                 requestURI.startsWith("/public")) {
             filterChain.doFilter(request, response);
             return;


### PR DESCRIPTION
RequestBody로 memberId받는 로직에서 CustomUser로 memberId받는 로직으로 수정하였습니다.
PathVariable같은 거는 토큰 memberId와 PathVariable memberId를 비교하는 로직도 추가했습니다.